### PR TITLE
fix: display walk times in local timezone instead of UTC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ DATABASE_URL=mysql+aiomysql://dogwalker:your_password_here@mysql:3306/dogwalker
 
 # Telegram Mini App URL — set manually or leave empty to auto-discover via tunnel
 WEBAPP_URL=
+
+# Timezone for displaying walk times (IANA timezone name)
+DISPLAY_TIMEZONE=Europe/Moscow

--- a/src/bot/config.py
+++ b/src/bot/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
     database_url: str = "mysql+aiomysql://dogwalker:dogwalker@mysql:3306/dogwalker"
     allowed_users: list[int] = []
     webapp_url: str = ""
+    display_timezone: str = "Europe/Moscow"
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/src/bot/notifications.py
+++ b/src/bot/notifications.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from aiogram import Bot
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.bot.config import settings
 from src.bot.i18n import get_text
 from src.database import crud
 
@@ -18,9 +20,10 @@ async def broadcast_walk(session: AsyncSession, walk, walker_user, bot: Bot) -> 
     logger.info(f"Broadcasting walk {walk.id} to {len(all_users)} users")
 
     username = walker_user.display_name or walker_user.username or f"User {walker_user.telegram_id}"
-    now = datetime.now(timezone.utc)
+    tz = ZoneInfo(settings.display_timezone)
+    now = datetime.now(timezone.utc).astimezone(tz)
     time_now = now.strftime("%H:%M")
-    time_walked = walk.walked_at.strftime("%H:%M")
+    time_walked = walk.walked_at.replace(tzinfo=timezone.utc).astimezone(tz).strftime("%H:%M")
 
     for user in all_users:
         message = get_text("walk_logged", user.language).format(


### PR DESCRIPTION
Times were stored as naive UTC datetimes but displayed as-is. Add a configurable DISPLAY_TIMEZONE setting (default: Europe/Moscow / UTC+3) and convert times before formatting notification messages.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)